### PR TITLE
Add Messages tab

### DIFF
--- a/Circles.xcodeproj/project.pbxproj
+++ b/Circles.xcodeproj/project.pbxproj
@@ -144,6 +144,11 @@
 		A54BA3A928529BE500453D5E /* SetupScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A54BA3A828529BE500453D5E /* SetupScreen.swift */; };
 		A553303F2B65689700695436 /* RoomCryptoInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A553303E2B65689700695436 /* RoomCryptoInfoView.swift */; };
 		A55330412B6826C500695436 /* SecretStorageCreationScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55330402B6826C500695436 /* SecretStorageCreationScreen.swift */; };
+		A5582CDC2C54122900507D9D /* ChatOverviewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5582CDB2C54122900507D9D /* ChatOverviewScreen.swift */; };
+		A5582CDE2C54150000507D9D /* ChatOverviewRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5582CDD2C54150000507D9D /* ChatOverviewRow.swift */; };
+		A5582CE02C54159700507D9D /* ChatCreationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5582CDF2C54159700507D9D /* ChatCreationSheet.swift */; };
+		A5582CE22C54179600507D9D /* ChatTimelineScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5582CE12C54179600507D9D /* ChatTimelineScreen.swift */; };
+		A5582CE42C5418B700507D9D /* ChatSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5582CE32C5418B700507D9D /* ChatSettingsView.swift */; };
 		A55B8F1E2A8D761A00BAA1FD /* SecretStoragePasswordScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55B8F1D2A8D761A00BAA1FD /* SecretStoragePasswordScreen.swift */; };
 		A55F367329EDB66300F46971 /* GalleryInviteCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55F367229EDB66300F46971 /* GalleryInviteCard.swift */; };
 		A55F367529EEE7EA00F46971 /* PhotoDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55F367429EEE7EA00F46971 /* PhotoDetailView.swift */; };
@@ -404,6 +409,11 @@
 		A54BA3A828529BE500453D5E /* SetupScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupScreen.swift; sourceTree = "<group>"; };
 		A553303E2B65689700695436 /* RoomCryptoInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCryptoInfoView.swift; sourceTree = "<group>"; };
 		A55330402B6826C500695436 /* SecretStorageCreationScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretStorageCreationScreen.swift; sourceTree = "<group>"; };
+		A5582CDB2C54122900507D9D /* ChatOverviewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatOverviewScreen.swift; sourceTree = "<group>"; };
+		A5582CDD2C54150000507D9D /* ChatOverviewRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatOverviewRow.swift; sourceTree = "<group>"; };
+		A5582CDF2C54159700507D9D /* ChatCreationSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatCreationSheet.swift; sourceTree = "<group>"; };
+		A5582CE12C54179600507D9D /* ChatTimelineScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTimelineScreen.swift; sourceTree = "<group>"; };
+		A5582CE32C5418B700507D9D /* ChatSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSettingsView.swift; sourceTree = "<group>"; };
 		A55B8F1D2A8D761A00BAA1FD /* SecretStoragePasswordScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretStoragePasswordScreen.swift; sourceTree = "<group>"; };
 		A55F367229EDB66300F46971 /* GalleryInviteCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryInviteCard.swift; sourceTree = "<group>"; };
 		A55F367429EEE7EA00F46971 /* PhotoDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoDetailView.swift; sourceTree = "<group>"; };
@@ -653,6 +663,7 @@
 		409F430C265DE0CE00690A61 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				A5582CDA2C5411D000507D9D /* Chat */,
 				422C08F22C1352CA00ADE377 /* View+Extensions */,
 				A54A83092C066E8000CE4000 /* Help */,
 				A562C08D2AFE8EA800522FCB /* CirclesLogoView.swift */,
@@ -914,6 +925,18 @@
 				A54A83102C08D0F000CE4000 /* SetupAddNewCircleSheet.swift */,
 			);
 			path = Setup;
+			sourceTree = "<group>";
+		};
+		A5582CDA2C5411D000507D9D /* Chat */ = {
+			isa = PBXGroup;
+			children = (
+				A5582CDB2C54122900507D9D /* ChatOverviewScreen.swift */,
+				A5582CDD2C54150000507D9D /* ChatOverviewRow.swift */,
+				A5582CDF2C54159700507D9D /* ChatCreationSheet.swift */,
+				A5582CE12C54179600507D9D /* ChatTimelineScreen.swift */,
+				A5582CE32C5418B700507D9D /* ChatSettingsView.swift */,
+			);
+			path = Chat;
 			sourceTree = "<group>";
 		};
 		A5A40B6429D6088A009A17EE /* UIA */ = {
@@ -1192,6 +1215,7 @@
 				A55330412B6826C500695436 /* SecretStorageCreationScreen.swift in Sources */,
 				A52ACB932A7969F6005D90C5 /* GalleryInvitationsView.swift in Sources */,
 				409F4326265DE12600690A61 /* CloudImagePicker.swift in Sources */,
+				A5582CDE2C54150000507D9D /* ChatOverviewRow.swift in Sources */,
 				A54A27882A843BB200858846 /* GroupInvitationsIndicator.swift in Sources */,
 				A5A7E228282B06FD001A528D /* ApplicationState.swift in Sources */,
 				A5634FCC2C41DF4A00D60DFB /* UnifiedTimelineComposerSheet.swift in Sources */,
@@ -1218,6 +1242,7 @@
 				A52DF69029E8AB52008860C3 /* Color+extensions.swift in Sources */,
 				A5D3C9C12A708F1300B41CC0 /* DBZxcvbn.m in Sources */,
 				A5D3C9C32A708F1300B41CC0 /* DBScorer.m in Sources */,
+				A5582CE02C54159700507D9D /* ChatCreationSheet.swift in Sources */,
 				A55F367329EDB66300F46971 /* GalleryInviteCard.swift in Sources */,
 				409F4323265DE11900690A61 /* Constants.swift in Sources */,
 				A52C77542A89CCB8005D2C0B /* MessageThumbnail.swift in Sources */,
@@ -1275,6 +1300,7 @@
 				A56593612AEBE5D30003C244 /* Room+URL.swift in Sources */,
 				A54A83112C08D0F000CE4000 /* SetupAddNewCircleSheet.swift in Sources */,
 				409F4370265DE24000690A61 /* PersonHeaderRow.swift in Sources */,
+				A5582CE22C54179600507D9D /* ChatTimelineScreen.swift in Sources */,
 				409F4332265DE15F00690A61 /* CircleCreationSheet.swift in Sources */,
 				40CD7F6F2667E16100DE315F /* VideoPicker.swift in Sources */,
 				A53E91322A5F152D007B0196 /* AcknowledgementsView.swift in Sources */,
@@ -1287,6 +1313,7 @@
 				A5921EB72AFAD5E400C2331D /* CircleFollowingRow.swift in Sources */,
 				A57BD8442BD1996800EC07E9 /* FollowersView.swift in Sources */,
 				A56BE17B2AD6ED4000B15F51 /* ScanQrCodeAndKnockSheet.swift in Sources */,
+				A5582CE42C5418B700507D9D /* ChatSettingsView.swift in Sources */,
 				A5B74F422BC5F92900299D90 /* KnockOnRoomView.swift in Sources */,
 				A54A278C2A843C5F00858846 /* InvitedGroupCard.swift in Sources */,
 				A562C0962B165E5C00522FCB /* SubscriptionSettingsView.swift in Sources */,
@@ -1318,6 +1345,7 @@
 				424CEE0C2C1B7AF9005D871C /* UIDevice+Extensions.swift in Sources */,
 				A553303F2B65689700695436 /* RoomCryptoInfoView.swift in Sources */,
 				A53E91222A5623F9007B0196 /* ProfileSettingsView.swift in Sources */,
+				A5582CDC2C54122900507D9D /* ChatOverviewScreen.swift in Sources */,
 				409F4315265DE0F400690A61 /* ImagePicker.swift in Sources */,
 				A565935F2AEAC4920003C244 /* QR.swift in Sources */,
 				A52DF68129E59A81008860C3 /* RoomAvatarView.swift in Sources */,

--- a/Circles/Backend/CirclesApplicationSession.swift
+++ b/Circles/Backend/CirclesApplicationSession.swift
@@ -42,6 +42,7 @@ class CirclesApplicationSession: ObservableObject {
             case circles
             case people
             case groups
+            case chat
             case photos
             case settings
         }
@@ -51,6 +52,7 @@ class CirclesApplicationSession: ObservableObject {
         @Published var selectedGroupId: RoomId?
         @Published var selectedTimelineId: RoomId?
         @Published var selectedGalleryId: RoomId?
+        @Published var selectedChatId: RoomId?
         
         @MainActor
         func navigate(tab: Tab, selected: RoomId?) {
@@ -65,6 +67,9 @@ class CirclesApplicationSession: ObservableObject {
             case .groups:
                 self.tab = .groups
                 self.selectedGroupId = selected
+            case .chat:
+                self.tab = .chat
+                self.selectedChatId = selected
             case .photos:
                 self.tab = .photos
                 self.selectedGalleryId = selected

--- a/Circles/CirclesTabbedInterface.swift
+++ b/Circles/CirclesTabbedInterface.swift
@@ -88,7 +88,7 @@ struct CirclesTabbedInterface: View {
             .environmentObject(session)
             .tabItem {
                 Image(systemName: SystemImages.bubble.rawValue)
-                Text("Chat")
+                Text("Messages")
             }
             .tag(Tab.chat)
             

--- a/Circles/CirclesTabbedInterface.swift
+++ b/Circles/CirclesTabbedInterface.swift
@@ -83,6 +83,15 @@ struct CirclesTabbedInterface: View {
                 }
                 .tag(Tab.groups)
             
+            ChatOverviewScreen(session: self.session.matrix,
+                               selected: $session.viewState.selectedChatId)
+            .environmentObject(session)
+            .tabItem {
+                Image(systemName: SystemImages.bubble.rawValue)
+                Text("Chat")
+            }
+            .tag(Tab.chat)
+            
             PeopleOverviewScreen(people: self.session.people,
                                  profile: self.session.profile,
                                  timelines: self.session.timelines,

--- a/Circles/Constants.swift
+++ b/Circles/Constants.swift
@@ -155,6 +155,7 @@ enum SystemImages: String {
     
     // MARK: - Once
     case bubbleLeftAndBubbleRightFill = "bubble.left.and.bubble.right.fill"
+    case bubble = "bubble"
     case bubbleRight = "bubble.right"
     case circle = "circle"
     case circlesHexagonpath = "circles.hexagonpath"

--- a/Circles/Views/Chat/ChatCreationSheet.swift
+++ b/Circles/Views/Chat/ChatCreationSheet.swift
@@ -1,0 +1,180 @@
+//
+//  ChatCreationSheet.swift
+//  Circles
+//
+//  Created by Charles Wright on 7/26/24.
+//
+
+import SwiftUI
+import PhotosUI
+import Matrix
+
+struct ChatCreationSheet: View {
+    @ObservedObject var session: Matrix.Session
+    @Environment(\.presentationMode) var presentation
+    
+    @State var roomName: String = ""
+    @State var roomTopic: String = ""
+    
+    @State var newestUserId: String = ""
+    @State var users: [Matrix.User] = []
+    
+    @State var headerImage: UIImage? = nil
+    @State var showPicker = false
+    @State var selectedItem: PhotosPickerItem?
+    
+    @State var defaultPowerLevel = PowerLevel(power: 0)
+    
+    @State private var alertTitle: String = ""
+    @State private var alertMessage: String = ""
+    @State private var showAlert = false
+    
+    @FocusState var inputFocused
+    
+    func create() async throws {
+        let powerLevels = RoomPowerLevelsContent(invite: 50, usersDefault: defaultPowerLevel.power)
+        guard let roomId = try? await session.createRoom(name: self.roomName,
+                                                         type: nil,
+                                                         encrypted: true,
+                                                         invite: self.users.map { $0.userId },
+                                                         powerLevelContentOverride: powerLevels),
+              let room = try await session.getRoom(roomId: roomId)
+        else {
+            // Set error message
+            return
+        }
+        
+        if let avatar = self.headerImage {
+            do {
+                try await room.setAvatarImage(image: avatar)
+            } catch {
+                // Move on with life.. we can fix the avatar later
+            }
+        }
+        
+        if !self.roomTopic.isEmpty {
+            do {
+                try await room.setTopic(newTopic: self.roomTopic)
+            } catch {
+                // Move on with life.. we can fix the topic later
+            }
+        }
+        
+        self.presentation.wrappedValue.dismiss()
+    }
+    
+    @ViewBuilder
+    var buttonbar: some View {
+        HStack {
+            Button(action: {
+                self.presentation.wrappedValue.dismiss()
+            })
+            {
+                Text("Cancel")
+            }
+            
+            Spacer()
+        }
+    }
+    
+    var body: some View {
+        VStack {
+            buttonbar
+            let frameWidth = 300.0
+            let frameHeight = 200.0
+      
+            ZStack {
+                if let img = self.headerImage {
+                    Image(uiImage: img)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(maxWidth: frameWidth, maxHeight: frameHeight)
+
+                } else {
+                    Color.gray
+                        .frame(width: frameWidth, height: frameHeight)
+                }
+
+                VStack {
+                    Text(self.roomName)
+                        .font(.title2)
+                        .fontWeight(.bold)
+                        .multilineTextAlignment(.center)
+                        .foregroundColor(Color.white)
+                        .shadow(color: Color.black, radius: 3.0)
+                        .minimumScaleFactor(0.8)
+                        .padding()
+                    
+                    Text(self.roomTopic)
+                        .font(.subheadline)
+                        .fontWeight(.bold)
+                        .multilineTextAlignment(.center)
+                        .foregroundColor(Color.white)
+                        .shadow(color: Color.black, radius: 3.0)
+                        .padding(.horizontal)
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .frame(maxWidth: frameWidth, maxHeight: frameHeight)
+            .overlay(alignment: .bottomTrailing) {
+                
+                PhotosPicker(selection: $selectedItem, matching: .images) {
+                    Image(systemName: SystemImages.pencilCircleFill.rawValue)
+                        .symbolRenderingMode(.multicolor)
+                        .font(.system(size: 30))
+                        .foregroundColor(.accentColor)
+                }
+                .buttonStyle(.borderless)
+
+            }
+            .onChange(of: selectedItem) { newItem in
+                Task {
+                    if let data = try? await newItem?.loadTransferable(type: Data.self),
+                       let img = UIImage(data: data)
+                    {
+                        await MainActor.run {
+                            self.headerImage = img
+                        }
+                    }
+                }
+            }
+            
+            TextField("Chat name", text: $roomName)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .textInputAutocapitalization(.words)
+                .focused($inputFocused)
+                .padding(.horizontal)
+                .onAppear {
+                    self.inputFocused = true
+                }
+            
+            HStack {
+                Text("Default user role")
+                Spacer()
+                Picker("User permissions", selection: $defaultPowerLevel) {
+                    ForEach(CIRCLES_POWER_LEVELS) { level in
+                        Text(level.description)
+                            .tag(level)
+                    }
+                }
+            }
+            .padding(.horizontal)
+            
+            Spacer()
+
+            AsyncButton(action: {
+                try await create()
+            })
+            {
+                Text("Create chat")
+            }
+            .buttonStyle(BigRoundedButtonStyle())
+            .disabled(roomName.isEmpty)
+            
+            Spacer()
+
+        }
+        .padding()
+    }
+    
+}

--- a/Circles/Views/Chat/ChatOverviewRow.swift
+++ b/Circles/Views/Chat/ChatOverviewRow.swift
@@ -1,0 +1,91 @@
+//
+//  ChatOverviewRow.swift
+//  Circles
+//
+//  Created by Charles Wright on 7/26/24.
+//
+
+import SwiftUI
+import Matrix
+
+struct ChatOverviewRow: View {
+    @ObservedObject var room: Matrix.Room
+    
+    @State var showConfirmLeave = false
+
+    var body: some View {
+        HStack(alignment: .center) {
+            RoomAvatarView(room: room, avatarText: .oneLetter)
+                .frame(width: 80, height: 80)
+                .padding(.leading, 5)
+            
+            VStack(alignment: .leading) {
+                HStack(alignment: .center, spacing: 3) {
+                    Text(room.name ?? room.id)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
+                        .font(.title2)
+                        .fontWeight(.bold)
+                        .foregroundColor(.greyCool1000)
+                        .minimumScaleFactor(0.8)
+                    Spacer()
+                }
+                .padding(.bottom, 4)
+
+                VStack(alignment: .leading) {
+                    if DebugModel.shared.debugMode {
+                        Text(room.roomId.stringValue)
+                            .font(.subheadline)
+                            .foregroundColor(.red)
+                    }
+                    
+                    HStack(spacing: 12  ) {
+                        HStack(spacing: 2) {
+                            Text("\(Image(systemName: "person.2"))")
+                            Text("\(room.joinedMembers.count)")
+                        }
+                        
+                        if room.unread > 0 {
+                            HStack(spacing: 2) {
+                                Text("\(Image(systemName: "circle.fill"))")
+                                Text("\(room.unread)")
+                            }
+                        } else {
+                            let formattedTimestamp = RelativeTimestampFormatter.format(date: room.timestamp)
+                            HStack(spacing: 2) {
+                                Text("\(Image(systemName: "clock"))")
+                                Text(formattedTimestamp)
+                            }
+                        }
+                    }
+                                        
+                    let knockCount = room.knockingMembers.count
+                    if room.iCanInvite && room.iCanKick && knockCount > 0 {
+                        let color = Color(light: .accentColor, dark: .white)
+                        Label("\(knockCount) request(s) for invitation", systemImage: "star.fill")
+                            .foregroundColor(color)
+                    }
+                }
+                .font(.footnote)
+                .foregroundColor(.greyCool800)
+            }
+            .padding(.top, 5)
+        }
+        .contextMenu {
+            Button(role: .destructive, action: {
+                self.showConfirmLeave = true
+            }) {
+                Label("Leave chat", systemImage: SystemImages.xmarkBin.rawValue)
+            }
+        }
+        .confirmationDialog(Text("Confirm Leaving Chat"),
+                            isPresented: $showConfirmLeave,
+                            actions: { //rm in
+            AsyncButton(role: .destructive, action: {
+                try await room.leave()
+            }) {
+                Text("Leave \(room.name ?? "this chat")")
+            }
+        })
+    }
+}

--- a/Circles/Views/Chat/ChatOverviewScreen.swift
+++ b/Circles/Views/Chat/ChatOverviewScreen.swift
@@ -1,0 +1,151 @@
+//
+//  MessagesOverviewScreen.swift
+//  Circles
+//
+//  Created by Charles Wright on 7/26/24.
+//
+
+import SwiftUI
+
+import Matrix
+import MarkdownUI
+import CodeScanner
+
+enum ChatOverviewSheetType: String {
+    case create
+    case scanQR
+}
+extension ChatOverviewSheetType: Identifiable {
+    var id: String { rawValue }
+}
+
+struct ChatOverviewScreen: View {
+    @ObservedObject var session: Matrix.Session
+    @State var sheetType: ChatOverviewSheetType?
+        
+    @State var invitations: [Matrix.InvitedRoom] = []
+    
+    //@State var selectedRoom: Matrix.Room?
+    @Binding var selected: RoomId?
+    
+    @ViewBuilder
+    var baseLayer: some View {
+       // let groupInvitations = container.session.invitations.values.filter { $0.type == ROOM_TYPE_GROUP }
+        
+        let rooms = session.rooms.values
+            .filter({ $0.type == nil })
+            .sorted(by: {$0.timestamp > $1.timestamp} )
+        
+        if !rooms.isEmpty || !invitations.isEmpty  {
+            VStack(alignment: .leading, spacing: 0) {
+                //ChatInvitationsIndicator(session: session)
+                
+                List(selection: $selected) {
+                    ForEach(rooms) { room in
+                        NavigationLink(value: room.roomId) {
+                            ChatOverviewRow(room: room)
+                                .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .listRowBackground(selected == room.roomId ? Color.accentColor.opacity(0.20) : Color.greyCool200)
+                    }
+                }
+                .listStyle(.plain)
+            }
+        }
+        else {
+            Text("Create a new chat to get started")
+                .onAppear {
+                    self.reload()
+                }
+        }
+    }
+    
+    @MainActor
+    func reload() {
+        print("RELOAD\tSession has \(session.invitations.count) invitations total")
+        self.invitations = session.invitations.values.filter { $0.type == nil }
+        print("RELOAD\tFound \(self.invitations.count) invitations for this screen")
+        session.objectWillChange.send()
+    }
+    
+    @ViewBuilder
+    var overlay: some View {
+        VStack {
+            Spacer()
+            HStack {
+                Spacer()
+                Menu {
+                    Button(action: {
+                        self.sheetType = .create
+                    }) {
+                        Label("New chat", systemImage: "plus.square.fill")
+                    }
+                }
+                label: {
+                    Image(systemName: SystemImages.plusCircleFill.rawValue)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: 50, height: 50)
+                        .padding()
+                }
+            }
+        }
+    }
+    
+    @ViewBuilder
+    var master: some View {
+        ZStack {
+            baseLayer
+                .scrollContentBackground(.hidden)
+
+            
+            overlay
+        }
+        .padding(.top)
+        .navigationBarTitle(Text("Chat"), displayMode: .inline)
+        .refreshable {
+            self.reload()
+        }
+        .toolbar {
+            ToolbarItemGroup(placement: .automatic) {
+                Menu {
+                    Button(action: {
+                        self.sheetType = .create
+                    }) {
+                        Label("New Chat", systemImage: "plus.circle")
+                    }
+                }
+                label: {
+                    Label("More", systemImage: SystemImages.ellipsisCircle.rawValue)
+                }
+            }
+        }
+        .sheet(item: $sheetType) { st in
+            // Figure out what kind of sheet we need
+            switch(st) {
+            case .create:
+                ChatCreationSheet(session: session)
+            case .scanQR:
+                ScanQrCodeAndKnockSheet(session: session)
+            }
+        }
+    }
+    
+    var body: some View {
+        NavigationSplitView {
+            master
+                .background(Color.greyCool200)
+        } detail: {
+            if let roomId = selected,
+               let room = session.rooms[roomId]
+            {
+                ChatTimelineScreen(room: room)
+            } else {
+                Text("Select a chat to see the most recent posts, or create a new chat")
+            }
+        }
+
+    }
+}
+

--- a/Circles/Views/Chat/ChatOverviewScreen.swift
+++ b/Circles/Views/Chat/ChatOverviewScreen.swift
@@ -103,7 +103,7 @@ struct ChatOverviewScreen: View {
             overlay
         }
         .padding(.top)
-        .navigationBarTitle(Text("Chat"), displayMode: .inline)
+        .navigationBarTitle(Text("Messages"), displayMode: .inline)
         .refreshable {
             self.reload()
         }

--- a/Circles/Views/Chat/ChatSettingsView.swift
+++ b/Circles/Views/Chat/ChatSettingsView.swift
@@ -1,0 +1,254 @@
+//
+//  ChatSettingsView.swift
+//  Circles
+//
+//  Created by Charles Wright on 7/26/24.
+//
+
+import SwiftUI
+import PhotosUI
+import Matrix
+
+struct ChatSettingsView: View {
+    @ObservedObject var room: Matrix.Room
+    
+    @Environment(\.presentationMode) var presentation
+
+    @State var newAvatarImageItem: PhotosPickerItem?
+    
+    @State var showConfirmLeave = false
+    @State var showInviteSheet = false
+    @State var showShareSheet = false
+    
+    let users: [UserId]
+    let admins: [UserId]
+    let mods: [UserId]
+    let members: [UserId]
+    
+    init(room: Matrix.Room) {
+        self.room = room
+        
+        self.users = room.joinedMembers
+        self.admins = users.filter { userId in
+            room.getPowerLevel(userId: userId) >= 100
+        }
+        self.mods = users.filter { userId in
+            let power = room.getPowerLevel(userId: userId)
+            return power < 100 && power >= 50
+        }
+        self.members = users.filter { userId in
+            room.getPowerLevel(userId: userId) < 50
+        }
+    }
+    
+    @ViewBuilder
+    var generalSection: some View {
+        Section("General") {
+            NavigationLink(destination: RoomRenameView(room: room)) {
+                Text("Group name")
+                    .badge(abbreviate(room.name))
+            }
+            
+            HStack {
+                Text("Cover image")
+                Spacer()
+                
+                if room.iCanChangeState(type: M_ROOM_AVATAR) {
+                    PhotosPicker(selection: $newAvatarImageItem, matching: .images) {
+                        RoomAvatarView(room: room, avatarText: .none)
+                            .frame(width: 80, height: 80)
+                    }
+                    .buttonStyle(.plain)
+                    .onChange(of: newAvatarImageItem) { _ in
+                        Task {
+                            if let data = try? await newAvatarImageItem?.loadTransferable(type: Data.self) {
+                                
+                                if let img = UIImage(data: data) {
+                                    try await room.setAvatarImage(image: img)
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    RoomAvatarView(room: room, avatarText: .none)
+                        .frame(width: 80, height: 80)
+                }
+            }
+            
+            let creator = room.session.getUser(userId: room.creator)
+            Text("Created by")
+                .badge(creator.displayName ?? creator.userId.stringValue)
+            
+            NavigationLink(destination: RoomTopicEditorView(room: room)) {
+                Text("Topic")
+                    .badge(room.topic ?? "(none)")
+            }
+            
+            if DebugModel.shared.debugMode {
+                Text("Matrix roomId")
+                    .badge(room.roomId.stringValue)
+            }
+            
+        }
+    }
+        
+    @ViewBuilder
+    var sharingSection: some View {
+        if room.joinRule == .knock,
+           let url = URL(string: "https://\(CIRCLES_PRIMARY_DOMAIN)/chat/\(room.roomId.stringValue)")
+        {
+            Section("Sharing") {
+                 if let qr = qrCode(url: url) {
+                     HStack {
+                         Text("QR code")
+                         Spacer()
+                         Button(action: {
+                             showShareSheet = true
+                         }) {
+                             Image(uiImage: qr)
+                                 .resizable()
+                                 .scaledToFill()
+                                 .frame(width: 80, height: 80)
+                         }
+                         .sheet(isPresented: $showShareSheet) {
+                             RoomShareSheet(room: room, url: url)
+                         }
+                     }
+                 }
+                HStack {
+                    Text("Link")
+                    Spacer()
+                    ShareLink("Share", item: url)
+                }
+            }
+        }
+    }
+    
+
+    
+    var body: some View {
+        Form {
+            generalSection
+            
+            sharingSection
+            
+            if !admins.isEmpty {
+                RoomMembersSection(title: "Administrators",
+                                   users: admins,
+                                   room: room)
+            }
+            
+            if !mods.isEmpty {
+                RoomMembersSection(title: "Moderators",
+                                   users: mods,
+                                   room: room)
+            }
+            
+            if !members.isEmpty {
+                RoomMembersSection(title: "Regular Members",
+                                   users: members,
+                                   room: room)
+            }
+            
+            let invited = room.invitedMembers
+            if !invited.isEmpty {
+                Section("Invited Members") {
+                    ForEach(invited) { userId in
+                        let user = room.session.getUser(userId: userId)
+                        RoomInvitedMemberRow(room: room, user: user)
+                    }
+                }
+            }
+            
+            if room.iCanInvite {
+                Button(action: {
+                    self.showInviteSheet = true
+                }) {
+                    Label("Invite new members", systemImage: SystemImages.personCropCircleBadgePlus.rawValue)
+                }
+                .sheet(isPresented: $showInviteSheet) {
+                    RoomInviteSheet(room: room)
+                }
+            }
+            
+            let banned = room.bannedMembers
+            if !banned.isEmpty {
+                Section("Banned Members") {
+                    ForEach(banned) { userId in
+                        let user = room.session.getUser(userId: userId)
+                        BannedRoomMemberRow(user: user, room: room)
+                    }
+                }
+            }
+            
+            if DebugModel.shared.debugMode {
+                RoomDebugDetailsSection(room: room)
+            }
+            
+            if room.iCanChangeState(type: M_ROOM_POWER_LEVELS) {
+                Section("User Permissions") {
+                    RoomDefaultPowerLevelPicker(room: room)
+                }
+            }
+            
+            Section("Danger Zone") {
+                
+                let powerUsers = admins + mods
+                // Are we the only user with mod powers?
+                let iAmTheOnlyMod: Bool = powerUsers.contains(room.session.creds.userId) && powerUsers.count == 1
+
+                
+                Button(role: .destructive, action: {
+                    self.showConfirmLeave = true
+                }) {
+                    Label("Leave group", systemImage: SystemImages.xmark.rawValue)
+                        .foregroundColor(.red) // This is necessary because setting `role: .destructive` only changes the text color, not the icon 🙄
+                }
+                .confirmationDialog(
+                    "Confirm leaving group",
+                    isPresented: $showConfirmLeave,
+                    actions: {
+                        if iAmTheOnlyMod {
+                            // If so then we can't just up and leave, or the room will become unmoderated
+                            
+                            AsyncButton(role: .destructive, action: {
+                                try await room.close(kickEveryone: false)
+                            }) {
+                                Label("Archive the group and preserve old posts", systemImage: "archivebox")
+                            }
+                            
+                            AsyncButton(role: .destructive, action: {
+                                try await room.close(kickEveryone: true)
+                            }) {
+                                Label("Remove all members and delete the group", systemImage: SystemImages.trash.rawValue)
+                            }
+                            
+                        } else {
+                            // Otherwise no worries we can leave whenever without a problem
+                            
+                            AsyncButton(role: .destructive, action: {
+                                
+                                // FIXME: Sanity check - Are we leaving the room unmoderated?  Don't do that.
+                                
+                                try await room.leave()
+                                self.presentation.wrappedValue.dismiss()
+                            }) {
+                                Text("Leave \"\(room.name ?? "this group")\"")
+                            }
+                        }
+                    },
+                    message: {
+                        if iAmTheOnlyMod {
+                            Text("You are the only user with moderator power. If you leave, the chat will be closed to new posts.")
+                        } else {
+                            Text("Really leave \(room.name ?? "this chat")?")
+                        }
+                    }
+                )
+                
+            }
+        }
+        .navigationTitle("Chat Settings")
+    }
+}
+

--- a/Circles/Views/Chat/ChatTimelineScreen.swift
+++ b/Circles/Views/Chat/ChatTimelineScreen.swift
@@ -1,0 +1,111 @@
+//
+//  ChatTimelineScreen.swift
+//  Circles
+//
+//  Created by Charles Wright on 7/26/24.
+//
+
+import SwiftUI
+import Matrix
+
+enum ChatScreenSheetType: String {
+    case invite
+    case share
+}
+extension ChatScreenSheetType: Identifiable {
+    var id: String { rawValue }
+}
+
+struct ChatTimelineScreen: View {
+    @ObservedObject var room: Matrix.Room
+
+    @Environment(\.presentationMode) var presentation
+    
+    @State private var sheetType: ChatScreenSheetType? = nil
+
+    @State private var newImageForHeader = UIImage()
+    @State private var newImageForProfile = UIImage()
+    @State private var newImageForMessage = UIImage()
+    
+    @State private var confirmNewProfileImage = false
+    @State private var confirmNewHeaderImage = false
+    
+    @State private var newTopic = ""
+    @State private var showTopicPopover = false
+
+    @State var nilParentMessage: Matrix.Message? = nil
+    
+    var timeline: some View {
+        TimelineView<MessageCard>(room: room)
+    }
+    
+    var toolbarMenu: some View {
+        Menu {
+            NavigationLink(destination: ChatSettingsView(room: room)) {
+                Label("Settings", systemImage: SystemImages.gearshapeFill.rawValue)
+            }
+            
+            if room.iCanInvite {
+                Button(action: {
+                    self.sheetType = .invite
+                }) {
+                    Label("Invite new members", systemImage: SystemImages.personCropCircleBadgePlus.rawValue)
+                }
+            }
+            
+            Button(action: {
+                self.sheetType = .share
+            }) {
+                Label("Share", systemImage: SystemImages.squareAndArrowUp.rawValue)
+            }
+        }
+        label: {
+            Label("Settings", systemImage: SystemImages.gearshapeFill.rawValue)
+        }
+    }
+    
+    var title: Text {
+        Text(room.name ?? "(Unnamed Chat)")
+    }
+    
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .center) {
+                /*
+                 VStack(alignment: .leading) {
+                 Text("Debug Info")
+                 Text("roomId: \(group.room.id)")
+                 Text("type: \(group.room.type ?? "(none)")")
+                 }
+                 .font(.footnote)
+                 */
+                
+                if !room.knockingMembers.isEmpty {
+                    RoomKnockIndicator(room: room)
+                }
+                
+                timeline
+                    .sheet(item: $sheetType) { st in
+                        switch(st) {
+                        case .invite:
+                            RoomInviteSheet(room: room, title: "Invite new members to \(room.name ?? "(unnamed chat)")")
+                            
+                        case .share:
+                            let url = URL(string: "https://\(CIRCLES_PRIMARY_DOMAIN)/chat/\(room.roomId.stringValue)")
+                            RoomShareSheet(room: room, url: url)
+                        }
+                    }
+                    .padding([.top], -4)
+            }
+                
+            Text("Composer goes here")
+        }
+        .toolbar {
+            ToolbarItemGroup(placement: .automatic) {
+                toolbarMenu
+            }
+        }
+        .navigationBarTitle(title, displayMode: .inline)
+        .background(Color.greyCool200)
+    }
+}


### PR DESCRIPTION
This PR adds support for generic Matrix chat rooms, under the Messages tab at the top level of the logged-in interface.

Still to do:
* Port over the small composer from the CommentsView for use in the chat room
* Create a new version of the TimelineView for rendering a chat conversation -- Chronological order, message bubbles, etc
* Re-work the ChatCreationSheet to focus more on *who* you want to chat with, vs what you want to call the room